### PR TITLE
Add Leaflet map integration for renter map page

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "primeicons": "^7.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
-    "zone.js": "~0.15.0"
+    "zone.js": "~0.15.0",
+    "leaflet": "^1.9.4"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^19.2.12",
@@ -38,6 +39,7 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
-    "typescript": "~5.7.2"
+    "typescript": "~5.7.2",
+    "@types/leaflet": "^1.9.4"
   }
 }

--- a/src/app/renter/pages/map/map.page.css
+++ b/src/app/renter/pages/map/map.page.css
@@ -83,6 +83,10 @@
   background: #fafafa;
 }
 
+.station-list tr.selected {
+  background: #e0f2ff;
+}
+
 .station-list td.green {
   color: green;
   font-weight: bold;
@@ -161,13 +165,12 @@
   box-shadow: 0 1px 4px rgba(0,0,0,0.1);
 }
 
-.map-section iframe {
+.map-section #map {
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-  border: none;
 }
 
 @media (max-width: 768px) {

--- a/src/app/renter/pages/map/map.page.html
+++ b/src/app/renter/pages/map/map.page.html
@@ -30,7 +30,8 @@
         <tbody>
         <tr
           *ngFor="let s of filteredStations"
-          (click)="selectedStation = s"
+          [class.selected]="selectedStation?.name === s.name"
+          (click)="selectStation(s)"
         >
           <td>{{ s.name }}</td>
           <td [class.green]="s.bikes > 2" [class.yellow]="s.bikes <= 2">
@@ -65,10 +66,7 @@
     </div>
 
     <div class="map-section">
-      <iframe
-        [src]="mapUrl | safe"
-        allowfullscreen
-      ></iframe>
+      <div #mapContainer id="map"></div>
     </div>
   </div>
 </div>

--- a/src/app/renter/pages/map/map.page.ts
+++ b/src/app/renter/pages/map/map.page.ts
@@ -1,6 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, AfterViewInit, ElementRef, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import * as L from 'leaflet';
 import { SafePipe } from '../../../shared/pipes/safe.pipe';
 
 interface Station {
@@ -8,7 +9,17 @@ interface Station {
   bikes: number;
   distance: string;
   docks: number;
+  lat: number;
+  lng: number;
 }
+
+const STATIONS: Station[] = [
+  { name: 'Av. Arequipa', bikes: 3, distance: '200 m', docks: 13, lat: -12.105, lng: -77.035 },
+  { name: 'Plaza San Miguel', bikes: 5, distance: '460 m', docks: 10, lat: -12.079, lng: -77.087 },
+  { name: 'Parque Kennedy', bikes: 1, distance: '600 m', docks: 7, lat: -12.121, lng: -77.03 },
+  { name: 'Mercedes Gallagher de Parks', bikes: 5, distance: '120 m', docks: 9, lat: -12.096, lng: -77.044 },
+  { name: 'UPC', bikes: 2, distance: '10 m', docks: 10, lat: -12.105, lng: -76.963 }
+];
 
 @Component({
   selector: 'app-map-page',
@@ -17,19 +28,17 @@ interface Station {
   templateUrl: './map.page.html',
   styleUrls: ['./map.page.css']
 })
-export class MapPage {
+export class MapPage implements AfterViewInit {
+  @ViewChild('mapContainer') mapContainer?: ElementRef<HTMLDivElement>;
+
+  map?: L.Map;
+  markers: Record<string, L.Marker> = {};
+
   location = 'Lima';
   hasSearched = false;
 
-  stations: Station[] = [
-    { name: 'Av. Arequipa', bikes: 3, distance: '200 m', docks: 13 },
-    { name: 'Plaza San Miguel', bikes: 5, distance: '460 m', docks: 10 },
-    { name: 'Parque Kennedy', bikes: 1, distance: '600 m', docks: 7 },
-    { name: 'Mercedes Gallagher de Parks', bikes: 5, distance: '120 m', docks: 9 },
-    { name: 'UPC', bikes: 2, distance: '10 m', docks: 10 }
-  ];
-
-  filteredStations: Station[] = [...this.stations];
+  stations: Station[] = STATIONS;
+  filteredStations: Station[] = [...STATIONS];
   selectedStation: Station | null = null;
 
   get totalBikes(): number {
@@ -40,8 +49,49 @@ export class MapPage {
     return this.stations.reduce((sum, s) => sum + s.docks, 0);
   }
 
-  get mapUrl(): string {
-    return `https://www.google.com/maps?q=${encodeURIComponent(this.location)},+Peru&output=embed`;
+  ngAfterViewInit(): void {
+    if (!this.mapContainer) return;
+
+    this.map = L.map(this.mapContainer.nativeElement).setView(
+      [STATIONS[0].lat, STATIONS[0].lng],
+      13
+    );
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '© OpenStreetMap contributors'
+    }).addTo(this.map);
+
+    const greenIcon = L.icon({
+      iconUrl:
+        'https://cdn.jsdelivr.net/npm/leaflet-color-markers@1.1.1/img/marker-icon-green.png',
+      shadowUrl:
+        'https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/images/marker-shadow.png',
+      iconSize: [25, 41],
+      iconAnchor: [12, 41],
+      popupAnchor: [1, -34],
+      shadowSize: [41, 41]
+    });
+
+    const yellowIcon = L.icon({
+      iconUrl:
+        'https://cdn.jsdelivr.net/npm/leaflet-color-markers@1.1.1/img/marker-icon-yellow.png',
+      shadowUrl:
+        'https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/images/marker-shadow.png',
+      iconSize: [25, 41],
+      iconAnchor: [12, 41],
+      popupAnchor: [1, -34],
+      shadowSize: [41, 41]
+    });
+
+    STATIONS.forEach((station) => {
+      const icon = station.bikes > 2 ? greenIcon : yellowIcon;
+      const m = L.marker([station.lat, station.lng], { icon })
+        .addTo(this.map!)
+        .bindPopup(
+          `<strong>${station.name}</strong><br>${station.bikes} bicis libres`
+        );
+      this.markers[station.name] = m;
+    });
   }
 
   searchLocation(input: HTMLInputElement) {
@@ -52,5 +102,16 @@ export class MapPage {
       s.name.toLowerCase().includes(this.location.toLowerCase())
     );
     this.selectedStation = this.filteredStations[0] || null;
+  }
+
+  selectStation(station: Station) {
+    this.selectedStation = station;
+    if (this.map) {
+      this.map.setView([station.lat, station.lng], 15);
+      const marker = this.markers[station.name];
+      if (marker) {
+        marker.openPopup();
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- install leaflet typings in package.json
- show bike stations with Leaflet markers
- enable selecting a station and updating map view
- replace iframe with a proper map container
- style map container and selected station row

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684774532dec832e943633660cd83f33