### PR TITLE
Move language switcher into renter layout

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,2 +1,1 @@
-<app-language-switcher class="language-switcher"></app-language-switcher>
 <router-outlet></router-outlet>

--- a/src/app/renter/components/renter-layout/renter-layout.component.ts
+++ b/src/app/renter/components/renter-layout/renter-layout.component.ts
@@ -6,6 +6,7 @@ import { MatToolbarModule }  from '@angular/material/toolbar';
 import { MatIconModule }     from '@angular/material/icon';
 import { MatButtonModule }   from '@angular/material/button';
 import { SidebarComponent }  from '../../../shared/components/sidebar/sidebar.component';
+import { LanguageSwitcherComponent } from '../../../shared/components/language-switcher/language-switcher.component';
 
 @Component({
   selector: 'app-renter-layout',
@@ -17,7 +18,8 @@ import { SidebarComponent }  from '../../../shared/components/sidebar/sidebar.co
     MatToolbarModule,
     MatIconModule,
     MatButtonModule,
-    SidebarComponent
+    SidebarComponent,
+    LanguageSwitcherComponent
   ],
   template: `
     <mat-sidenav-container class="sidenav-container">
@@ -31,6 +33,7 @@ import { SidebarComponent }  from '../../../shared/components/sidebar/sidebar.co
           </button>
           <span>BikeShare</span>
           <span class="spacer"></span>
+          <app-language-switcher class="language-switcher"></app-language-switcher>
         </mat-toolbar>
 
         <main class="layout-main">

--- a/src/app/shared/components/language-switcher/language-switcher.component.css
+++ b/src/app/shared/components/language-switcher/language-switcher.component.css
@@ -5,3 +5,8 @@ mat-button-toggle-group {
 mat-button-toggle {
   text-transform: uppercase;
 }
+
+:host(.language-switcher) {
+  display: inline-flex;
+  align-items: center;
+}


### PR DESCRIPTION
## Summary
- display language switcher in the renter toolbar
- clean up app component
- add optional styling for host

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848bc7910d0832eae742abbfacb2c06