### PR TITLE
Fix translation module imports

### DIFF
--- a/src/app/public/pages/login/login.page.ts
+++ b/src/app/public/pages/login/login.page.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterLink, Router } from '@angular/router';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
-import { TranslateService } from '@ngx-translate/core';
+import { TranslateService, TranslateModule } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-login-page',

--- a/src/app/public/pages/register/register.page.ts
+++ b/src/app/public/pages/register/register.page.ts
@@ -3,7 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
-import { TranslateService } from '@ngx-translate/core';
+import { TranslateService, TranslateModule } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-register-page',

--- a/src/app/renter/pages/profile/profile.page.ts
+++ b/src/app/renter/pages/profile/profile.page.ts
@@ -13,6 +13,7 @@ import { Profile } from '../../model/profile.entity';
 import { User } from '../../model/user.entity';
 import { ProfileService } from '../../services/profile.service';
 import { UserService } from '../../services/user.service';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-profile-page',

--- a/src/app/renter/pages/support/support.page.ts
+++ b/src/app/renter/pages/support/support.page.ts
@@ -12,6 +12,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-support-page',


### PR DESCRIPTION
## Summary
- import `TranslateModule` where needed

## Testing
- `npx ng test --watch=false` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6848d2827f68832e8035f849b3e9ff2e