### PR TITLE
Update server base URL for Spring Boot backend

### DIFF
--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: false,
-  serverBaseUrl: 'http://localhost:3000/api/v1',
+  serverBaseUrl: 'http://localhost:8080/api/v1',
   usersEndpoint: '/users',
   profilesEndpoint: '/profiles',
 }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: true,
-  serverBaseUrl: 'http://localhost:3000',
+  serverBaseUrl: 'http://localhost:8080/api/v1',
   usersEndpoint: '/users',
   profilesEndpoint: '/profiles',
 }


### PR DESCRIPTION
## Summary
- use Spring Boot base URL `http://localhost:8080/api/v1` for both development and production environments
- verify services build endpoints from `serverBaseUrl`

## Testing
- `npm test` *(fails: Data path "" must NOT have additional properties(outputPath))*

------
https://chatgpt.com/codex/tasks/task_e_68542fe0262c832eae5b2573302e0571