### PR TITLE
Implement AuthService and refactor auth pages

### DIFF
--- a/src/app/public/pages/forgot-password/forgot-password.page.ts
+++ b/src/app/public/pages/forgot-password/forgot-password.page.ts
@@ -2,7 +2,8 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
-import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { HttpClientModule } from '@angular/common/http';
+import { AuthService } from 'src/app/shared/services/auth.service';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
 @Component({
@@ -14,10 +15,8 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
 })
 export class ForgotPasswordPage {
   email: string = '';
-  private apiUrl = 'https://6824eacb0f0188d7e72b5f57.mockapi.io/api/v1/users2';
-
   constructor(
-    private http: HttpClient,
+    private authService: AuthService,
     private router: Router,
     private translate: TranslateService
   ) {}
@@ -28,13 +27,13 @@ export class ForgotPasswordPage {
       return;
     }
 
-    this.http.get<any[]>(`${this.apiUrl}?email=${this.email}`).subscribe({
-      next: (users) => {
-        if (users && users.length > 0) {
-          const userId = users[0].id;
-          this.router.navigate(['/reset-password', userId]);
+    this.authService.forgotPassword(this.email).subscribe({
+      next: (res) => {
+        const id = res?.userId;
+        if (id) {
+          this.router.navigate(['/reset-password', id]);
         } else {
-          alert(this.translate.instant('ForgotPassword.UserNotFound'));
+          this.router.navigate(['/reset-password']);
         }
       },
       error: (err) => {

--- a/src/app/public/pages/login/login.page.ts
+++ b/src/app/public/pages/login/login.page.ts
@@ -2,7 +2,8 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterLink, Router } from '@angular/router';
-import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { HttpClientModule } from '@angular/common/http';
+import { AuthService } from 'src/app/shared/services/auth.service';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 
 @Component({
@@ -16,7 +17,7 @@ export class LoginPage {
   email = '';
   password = '';
 
-  constructor(private http: HttpClient, private router: Router, public translate: TranslateService) {}
+  constructor(private authService: AuthService, private router: Router, public translate: TranslateService) {}
   switchLanguage(language: string) {
     this.translate.use(language);
   }
@@ -31,21 +32,16 @@ export class LoginPage {
       alert(this.translate.instant('Login.ErrorEmptyFields'));
       return;
     }
-    const url = `https://6824eacb0f0188d7e72b5f57.mockapi.io/api/v1/users2?email=${this.email}`;
-    this.http.get<any[]>(url).subscribe({
-      next: users => {
-        if (users.length === 0) {
-          alert(this.translate.instant('Login.UserNotFound'));
-          return;
+    this.authService.login({ email: this.email, password: this.password }).subscribe({
+      next: (res) => {
+        const role = localStorage.getItem('userRole');
+        if (role === 'owner') {
+          this.router.navigate(['/owner/home']);
+        } else if (role === 'renter') {
+          this.router.navigate(['/renter/home']);
+        } else {
+          this.router.navigate(['/']);
         }
-        const user = users[0];
-        if (user.password !== this.password) {
-          alert(this.translate.instant('Login.WrongPassword'));
-          return;
-        }
-        localStorage.setItem('userId',    user.id);
-        localStorage.setItem('userRole', user.isOwner ? 'owner' : 'renter');
-        this.router.navigate([ user.isOwner ? '/owner/home' : '/renter/home' ]);
       },
       error: err => {
         console.error(err);

--- a/src/app/public/pages/register/register.page.ts
+++ b/src/app/public/pages/register/register.page.ts
@@ -2,7 +2,8 @@ import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { CommonModule } from '@angular/common';
-import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { HttpClientModule } from '@angular/common/http';
+import { AuthService } from 'src/app/shared/services/auth.service';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 
 @Component({
@@ -18,7 +19,7 @@ export class RegisterPage {
   password: string = '';
   isOwner: boolean = false;
 
-  constructor(private http: HttpClient, private router: Router, public translate: TranslateService) {}
+  constructor(private authService: AuthService, private router: Router, public translate: TranslateService) {}
   switchLanguage(language: string) {
     this.translate.use(language);
   }
@@ -31,19 +32,17 @@ export class RegisterPage {
       isOwner: this.isOwner
     };
 
-    this.http
-      .post('https://6824eacb0f0188d7e72b5f57.mockapi.io/api/v1/users2', newUser)
-      .subscribe({
-        next: (response) => {
-          alert(this.translate.instant('Register.UserRegistered'));
-          this.resetForm();
-          this.router.navigate(['/login']);
-        },
-        error: (error) => {
-          console.error('Error registering user:', error);
-          alert(this.translate.instant('Register.ErrorRegistering'));
-        }
-      });
+    this.authService.register(newUser).subscribe({
+      next: () => {
+        alert(this.translate.instant('Register.UserRegistered'));
+        this.resetForm();
+        this.router.navigate(['/login']);
+      },
+      error: (error) => {
+        console.error('Error registering user:', error);
+        alert(this.translate.instant('Register.ErrorRegistering'));
+      }
+    });
   }
 
   private resetForm() {

--- a/src/app/public/pages/reset-password/reset-password.page.ts
+++ b/src/app/public/pages/reset-password/reset-password.page.ts
@@ -2,7 +2,8 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { HttpClientModule } from '@angular/common/http';
+import { AuthService } from 'src/app/shared/services/auth.service';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
 @Component({
@@ -16,12 +17,11 @@ export class ResetPasswordPage implements OnInit {
   password = '';
   confirmPassword = '';
   private userId: string | null = null;
-  private apiUrl = 'https://6824eacb0f0188d7e72b5f57.mockapi.io/api/v1/users2';
 
   constructor(
     private route: ActivatedRoute,
     private router: Router,
-    private http: HttpClient,
+    private authService: AuthService,
     private translate: TranslateService
   ) {}
 
@@ -43,8 +43,8 @@ export class ResetPasswordPage implements OnInit {
       return;
     }
 
-    const updatedData = { password: this.password };
-    this.http.put(`${this.apiUrl}/${this.userId}`, updatedData).subscribe({
+    const id = this.userId ?? '';
+    this.authService.resetPassword(id, this.password).subscribe({
       next: () => {
         alert(this.translate.instant('ResetPassword.Success'));
         this.router.navigate(['/login']);

--- a/src/app/shared/services/auth.service.ts
+++ b/src/app/shared/services/auth.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, tap } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AuthService {
+  private apiUrl = '/auth';
+
+  constructor(private http: HttpClient) {}
+
+  login(credentials: { email: string; password: string }): Observable<any> {
+    return this.http.post<{ token?: string; user?: any }>(`${this.apiUrl}/login`, credentials).pipe(
+      tap(res => {
+        if (res.user) {
+          localStorage.setItem('userId', res.user.id);
+          const role = res.user.role || (res.user.isOwner ? 'owner' : 'renter');
+          if (role) {
+            localStorage.setItem('userRole', role);
+          }
+        }
+        if (res.token) {
+          localStorage.setItem('token', res.token);
+        }
+      })
+    );
+  }
+
+  register(data: any): Observable<any> {
+    return this.http.post(`${this.apiUrl}/register`, data);
+  }
+
+  forgotPassword(email: string): Observable<any> {
+    return this.http.post(`${this.apiUrl}/forgot-password`, { email });
+  }
+
+  resetPassword(token: string, password: string): Observable<any> {
+    return this.http.post(`${this.apiUrl}/reset-password`, { token, password });
+  }
+}


### PR DESCRIPTION
## Summary
- add `AuthService` with login/register methods and helpers for password recovery
- replace direct `HttpClient` calls in auth related pages with `AuthService`
- store user data in `AuthService` login method

## Testing
- `npm test` *(fails: Schema validation failed)*

------
https://chatgpt.com/codex/tasks/task_e_685431b9447c832eb1c3351a73d067a6