### PR TITLE
Load data via services

### DIFF
--- a/src/app/owner/pages/home/owner-home.page.html
+++ b/src/app/owner/pages/home/owner-home.page.html
@@ -1,4 +1,6 @@
-<div class="page-container" *ngIf="stats">
+<p *ngIf="loading">{{ 'Common.Loading' | translate }}</p>
+<p *ngIf="error">{{ 'Common.Error' | translate }}</p>
+<div class="page-container" *ngIf="stats && !loading && !error">
   <div class="main-content">
 
     <header class="welcome-header">

--- a/src/app/owner/pages/home/owner-home.page.ts
+++ b/src/app/owner/pages/home/owner-home.page.ts
@@ -8,6 +8,10 @@ import { CurrentUserService } from '../../../shared/services/current-user.servic
 import { DashboardStats } from '../../model/dashboard-stats.entity';
 import { Reservation } from '../../model/reservation.entity';
 import { Bike } from '../../model/bike.entity';
+import { DashboardService } from '../../service/dashboard.service';
+import { ReservationService } from '../../service/reservation.service';
+import { BikeService } from '../../service/bike.service';
+import { forkJoin } from 'rxjs';
 export interface RecentActivity {
   type: 'reservation' | 'review' | 'cancellation';
   person: string;
@@ -35,9 +39,14 @@ export class OwnerHomePage implements OnInit {
   pendingReservations: Reservation[] = [];
   recentActivities: RecentActivity[] = [];
   topBikes: Bike[] = [];
+  loading = false;
+  error = false;
   private router = inject(Router);
   private notificationService = inject(NotificationService);
   private currentUserService = inject(CurrentUserService);
+  private dashboardService = inject(DashboardService);
+  private reservationService = inject(ReservationService);
+  private bikeService = inject(BikeService);
 
   ngOnInit(): void {
     this.fetchOwnerName();
@@ -52,34 +61,25 @@ export class OwnerHomePage implements OnInit {
   }
 
   private loadDashboardData(): void {
-    this.stats = new DashboardStats({
-      monthlyIncome: 750.50,
-      pendingReservationsCount: 2,
-      activeBikesCount: 8,
-      ownerRating: 4.9
+    this.loading = true;
+    this.error = false;
+    forkJoin({
+      stats: this.dashboardService.getDashboardStats(),
+      reservations: this.reservationService.getPendingReservations(),
+      bikes: this.bikeService.getTopBikes()
+    }).subscribe({
+      next: ({ stats, reservations, bikes }) => {
+        this.stats = stats;
+        this.pendingReservations = reservations;
+        this.topBikes = bikes;
+        this.loading = false;
+      },
+      error: () => {
+        this.error = true;
+        this.loading = false;
+      }
     });
-    this.pendingReservations = [
-      new Reservation({ id: 1, renterName: 'Carlos Villa', bikeName: 'BMX Pro', date: new Date('2025-06-17T14:00:00'), status: 'Pending' }),
-      new Reservation({ id: 2, renterName: 'Lucía Fernández', bikeName: 'Vintage Verde', date: new Date('2025-06-18T10:00:00'), status: 'Pending' }),
-      new Reservation({ id: 3, renterName: 'Javier Soto', bikeName: 'Mountain X', date: new Date('2025-06-19T09:00:00'), status: 'Pending' })
-    ];
-    const allActivities: RecentActivity[] = [
-      { type: 'reservation',  person: 'Javier Soto',   bikeName: 'Mountain X',    timestamp: new Date() },
-      { type: 'review',       person: 'Maria Rojas',   bikeName: 'BMX Pro',       timestamp: new Date(Date.now() -  3 * 3600_000) },
-      { type: 'cancellation', person: 'Pedro Gomez',   bikeName: 'Vintage Verde', timestamp: new Date(Date.now() - 24 * 3600_000) },
-      { type: 'reservation',  person: 'Ana Ruiz',      bikeName: 'City Light',    timestamp: new Date(Date.now() - 48 * 3600_000) },
-      { type: 'review',       person: 'Luis Herrera',  bikeName: 'Urban Glide',   timestamp: new Date(Date.now() - 72 * 3600_000) },
-      { type: 'reservation',  person: 'Carla Vega',    bikeName: 'Trail Blazer',  timestamp: new Date(Date.now() - 96 * 3600_000) },
-      { type: 'cancellation', person: 'Andrés Patiño', bikeName: 'Speedster',     timestamp: new Date(Date.now() - 120 * 3600_000) },
-    ];
-    this.recentActivities = allActivities.slice(0, 7);
-    this.notificationService.setNotifications(this.recentActivities);
-    this.topBikes = [
-      new Bike({ id: 101, model: 'BMX Pro',        type: 'BMX',       rentalsThisMonth: 15, imageUrl: 'https://cdn.skatepro.com/product/520/mankind-thunder-20-bmx-freestyle-bike-8h.webp' }),
-      new Bike({ id: 102, model: 'Vintage Verde',  type: 'Urbana',    rentalsThisMonth: 12, imageUrl: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRdDydP4N9WKFYaT6cZoxxGCw5kL2BVGseLww&s' }),
-      new Bike({ id: 103, model: 'Mountain X',     type: 'Montañera', rentalsThisMonth:  9, imageUrl: 'https://cuponassets.cuponatic-latam.com/backendPe/uploads/imagenes_descuentos/102109/f001f03a7ed89e3960ac9e197306a6d70f138fac.XL2.jpg' }),
-      new Bike({ id: 104, model: 'City Light',     type: 'Urbana',    rentalsThisMonth:  8, imageUrl: 'https://via.placeholder.com/220x140?text=City+Light' }),
-    ];
+    this.notificationService.notifications$.subscribe(n => this.recentActivities = n);
   }
 
   navigateToAddBike(): void {

--- a/src/app/owner/pages/my-bikes/my-bikes.page.html
+++ b/src/app/owner/pages/my-bikes/my-bikes.page.html
@@ -1,4 +1,6 @@
 <div class="page-container">
+  <p *ngIf="loading">{{ 'Common.Loading' | translate }}</p>
+  <p *ngIf="error">{{ 'Common.Error' | translate }}</p>
 
   <ng-container *ngIf="!isEditing; else formView">
     <div class="page-layout">

--- a/src/app/owner/pages/my-bikes/my-bikes.page.ts
+++ b/src/app/owner/pages/my-bikes/my-bikes.page.ts
@@ -7,6 +7,7 @@ import * as L from 'leaflet';
 
 import { BikeFormComponent } from '../../components/bike-form/bike-form.component';
 import { Bike } from '../../model/bike.entity';
+import { BikeService } from '../../service/bike.service';
 
 @Component({
   selector: 'app-my-bikes-page',
@@ -38,7 +39,9 @@ export class MyBikesPage implements OnInit, OnDestroy {
     popupAnchor: [0, -40]
   });
 
-  constructor(private cdr: ChangeDetectorRef) {}
+  loading = false;
+  error = false;
+  constructor(private cdr: ChangeDetectorRef, private bikeService: BikeService) {}
 
   ngOnInit(): void {
     this.loadOwnerBikes();
@@ -48,11 +51,20 @@ export class MyBikesPage implements OnInit, OnDestroy {
   }
 
   loadOwnerBikes(): void {
-    this.myBikes = [
-      new Bike({ id: 101, model: 'BMX Pro', type: 'BMX', costPerMinute: 0.5, imageUrl: 'https://cdn.skatepro.com/product/520/mankind-thunder-20-bmx-freestyle-bike-8h.webp', lat: -12.085, lng: -77.050 }),
-      new Bike({ id: 102, model: 'Vintage Verde', type: 'Urbana', costPerMinute: 0.3, imageUrl: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRdDydP4N9WKFYaT6cZoxxGCw5kL2BVGseLww&s', lat: -12.095, lng: -77.045 }),
-      new Bike({ id: 103, model: 'Mountain X', type: 'Montañera', costPerMinute: 0.6, imageUrl: 'https://images.squarespace-cdn.com/content/v1/5c38c1a931d4dfa4282305a3/1547225184651-S2PO613H621C4G57EX7D/specialized-pitch-sport-womens-hardtail-mountain-bike-2019-gloss-storm-grey-acid-lava.jpg', lat: -12.090, lng: -77.060 }),
-    ];
+    this.loading = true;
+    this.error = false;
+    this.bikeService.getOwnerBikes().subscribe({
+      next: bikes => {
+        this.myBikes = bikes;
+        this.updateMarkers();
+        this.loading = false;
+        this.cdr.detectChanges();
+      },
+      error: () => {
+        this.error = true;
+        this.loading = false;
+      }
+    });
   }
   initMap(): void {
     this.map?.remove();

--- a/src/app/owner/pages/reservations/reservations.page.html
+++ b/src/app/owner/pages/reservations/reservations.page.html
@@ -1,4 +1,6 @@
-<div class="page-container">
+<p *ngIf="loading">{{ 'Common.Loading' | translate }}</p>
+<p *ngIf="error">{{ 'Common.Error' | translate }}</p>
+<div class="page-container" *ngIf="!loading && !error">
   <header class="page-header">
     <h1>{{ 'Reservations.Title' | translate }}</h1>
     <p>{{ 'Reservations.Subtitle' | translate }}</p>

--- a/src/app/owner/pages/reservations/reservations.page.ts
+++ b/src/app/owner/pages/reservations/reservations.page.ts
@@ -16,6 +16,8 @@ import { ReservationService } from '../../service/reservation.service';
 })
 export class ReservationsPage implements OnInit {
   allReservations: Reservation[] = [];
+  loading = false;
+  error = false;
 
   private reservationService = inject(ReservationService);
   private translate = inject(TranslateService);
@@ -33,18 +35,22 @@ export class ReservationsPage implements OnInit {
   }
 
   ngOnInit(): void {
-    this.loadMockReservations();
+    this.loadReservations();
   }
 
-  loadMockReservations(): void {
-    const now = new Date();
-    this.allReservations = [
-      new Reservation({ id: 1, renterName: 'Carlos Villa', bikeName: 'BMX Pro', date: new Date(now.getTime() + 2 * 24 * 3600 * 1000), status: 'Pending', totalPrice: 25.00, renterImage: 'https://randomuser.me/api/portraits/men/32.jpg' }),
-      new Reservation({ id: 2, renterName: 'Lucía Fernández', bikeName: 'Vintage Verde', date: new Date(now.getTime() + 5 * 24 * 3600 * 1000), status: 'Accepted', totalPrice: 40.00, renterImage: 'https://randomuser.me/api/portraits/women/44.jpg' }),
-      new Reservation({ id: 3, renterName: 'Javier Soto', bikeName: 'Mountain X', date: new Date(now.getTime() - 7 * 24 * 3600 * 1000), endDate: new Date(now.getTime() - 6 * 24 * 3600 * 1000), status: 'Completed', totalPrice: 75.00, renterImage: 'https://randomuser.me/api/portraits/men/56.jpg' }),
-      new Reservation({ id: 4, renterName: 'Ana Gómez', bikeName: 'BMX Pro', date: new Date(now.getTime() - 10 * 24 * 3600 * 1000), status: 'Cancelled', totalPrice: 15.00, renterImage: 'https://randomuser.me/api/portraits/women/68.jpg' }),
-      new Reservation({ id: 5, renterName: 'Pedro Pascal', bikeName: 'Vintage Verde', date: new Date(now.getTime() - 15 * 24 * 3600 * 1000), status: 'Declined', totalPrice: 30.00, renterImage: 'https://randomuser.me/api/portraits/men/72.jpg' }),
-    ];
+  loadReservations(): void {
+    this.loading = true;
+    this.error = false;
+    this.reservationService.getPendingReservations().subscribe({
+      next: res => {
+        this.allReservations = res;
+        this.loading = false;
+      },
+      error: () => {
+        this.error = true;
+        this.loading = false;
+      }
+    });
   }
 
   accept(id: number) { console.log(`Aceptando reserva ${id}`); }

--- a/src/app/owner/pages/support/owner-support.page.html
+++ b/src/app/owner/pages/support/owner-support.page.html
@@ -1,4 +1,6 @@
-<div class="support-page-container">
+<p *ngIf="loading">{{ 'Common.Loading' | translate }}</p>
+<p *ngIf="error">{{ 'Common.Error' | translate }}</p>
+<div class="support-page-container" *ngIf="!loading && !error">
 
   <div class="support-card">
     <h2>{{ 'Support.LastRequests' | translate }}</h2>

--- a/src/app/owner/pages/support/owner-support.page.ts
+++ b/src/app/owner/pages/support/owner-support.page.ts
@@ -10,6 +10,7 @@ import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { SupportTicketDialogComponent } from '../../../shared/components/support-ticket-dialog/support-ticket-dialog.component';
+import { SupportService, SupportTicket } from '../../service/support.service';
 
 
 @Component({
@@ -35,12 +36,11 @@ export class OwnerSupportPage implements OnInit {
   private snackBar = inject(MatSnackBar);
   private translate = inject(TranslateService);
   private dialog = inject(MatDialog);
+  private supportService = inject(SupportService);
 
-  supportTickets: any[] = [
-    { id: 1, asunto: 'Problema con pago de un alquiler', fecha: '12/06/2025', estado: 'Resuelto' },
-    { id: 2, asunto: 'Arrendatario reportó daño en bicicleta', fecha: '10/06/2025', estado: 'En Proceso' },
-    { id: 3, asunto: 'Consulta sobre mis ganancias', fecha: '05/06/2025', estado: 'Resuelto' }
-  ];
+  supportTickets: SupportTicket[] = [];
+  loading = false;
+  error = false;
 
   newRequestForm: FormGroup;
   categories: string[] = [
@@ -61,7 +61,20 @@ export class OwnerSupportPage implements OnInit {
     });
   }
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.loading = true;
+    this.error = false;
+    this.supportService.getTickets().subscribe({
+      next: tickets => {
+        this.supportTickets = tickets;
+        this.loading = false;
+      },
+      error: () => {
+        this.error = true;
+        this.loading = false;
+      }
+    });
+  }
 
   onSubmit() {
     if (this.newRequestForm.valid) {

--- a/src/app/owner/service/bike.service.ts
+++ b/src/app/owner/service/bike.service.ts
@@ -16,4 +16,8 @@ export class BikeService {
   getTopBikes(): Observable<Bike[]> {
     return this.http.get<Bike[]>(`${environment.serverBaseUrl}/owner/bikes/top`);
   }
+
+  getOwnerBikes(): Observable<Bike[]> {
+    return this.http.get<Bike[]>(`${environment.serverBaseUrl}/owner/bikes`);
+  }
 }

--- a/src/app/owner/service/support.service.ts
+++ b/src/app/owner/service/support.service.ts
@@ -1,0 +1,20 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+
+export interface SupportTicket {
+  id: number;
+  asunto: string;
+  fecha: string;
+  estado: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class SupportService {
+  private http = inject(HttpClient);
+
+  getTickets(): Observable<SupportTicket[]> {
+    return this.http.get<SupportTicket[]>(`${environment.serverBaseUrl}/owner/support`);
+  }
+}

--- a/src/app/renter/pages/home/renter-home.page.html
+++ b/src/app/renter/pages/home/renter-home.page.html
@@ -1,4 +1,6 @@
-<div class="page-container" *ngIf="stats">
+<p *ngIf="loading">{{ 'Common.Loading' | translate }}</p>
+<p *ngIf="error">{{ 'Common.Error' | translate }}</p>
+<div class="page-container" *ngIf="stats && !loading && !error">
   <div class="main-content">
 
     <header class="welcome-header">

--- a/src/app/renter/pages/home/renter-home.page.ts
+++ b/src/app/renter/pages/home/renter-home.page.ts
@@ -3,8 +3,7 @@ import { CommonModule, CurrencyPipe, DatePipe } from '@angular/common';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
-import { of } from 'rxjs';
-import { delay } from 'rxjs/operators';
+import { DashboardService, RenterDashboardData } from '../../services/dashboard.service';
 import { MatIconModule } from '@angular/material/icon';
 
 import { CurrentUserService } from '../../../shared/services/current-user.service';
@@ -59,14 +58,14 @@ export class RenterHomePage implements OnInit {
   private currentUserService = inject(CurrentUserService);
   private dialog = inject(MatDialog);
   private snackBar = inject(MatSnackBar);
+  private dashboardService = inject(DashboardService);
   username = '';
   stats: RenterStats | null = null;
   upcomingReservation: UpcomingReservation | null = null;
   recentRentals: RentalHistory[] = [];
   recommendations: Recommendation[] = [];
-  private mockUpcomingReservations: UpcomingReservation[] = [
-    { id: 'res-001', bikeName: 'Bicicleta de Montaña Specialized', date: '2025-06-18T17:00:00.000Z', address: 'Parque Kennedy, Miraflores', bikeImage: 'https://www.monark.com.pe/static/monark-pe/uploads/products/images/bicicleta-monark-highlander-xt-aro-29-rojo-negro-01.jpg', ownerName: 'Ana' }
-  ];
+  loading = false;
+  error = false;
 
   ngOnInit(): void {
     this.currentUserService.currentUser$.subscribe(user => {
@@ -76,20 +75,20 @@ export class RenterHomePage implements OnInit {
   }
 
   loadDashboardData(): void {
-    of({}).pipe(delay(200)).subscribe(() => {
-      this.stats = { distanceTraveled: 54, rentalsCount: 8, drivingTime: 17, rating: 4.8 };
-      this.upcomingReservation = this.mockUpcomingReservations.length > 0 ? this.mockUpcomingReservations[0] : null;
-
-      this.recentRentals = [
-        { bikeName: 'Vintage',  date: '15 junio', status: 'Finalizado', location: 'Plaza San Miguel' },
-        { bikeName: 'Mountain', date: '11 junio', status: 'Finalizado', location: 'El Malecón' },
-        { bikeName: 'BMX',      date: '05 junio', status: 'Cancelada',  location: 'Av. La Marina' },
-      ];
-      this.recommendations = [
-        { id: 'bike-001', bikeName: 'Vintage verde', pricePerMinute: 0.5, distance: '400 m', imageUrl: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRdDydP4N9WKFYaT6cZoxxGCw5kL2BVGseLww&s' },
-        { id: 'bike-002', bikeName: 'Vintage rojo', pricePerMinute: 0.6, distance: '600 m', imageUrl: 'https://i.ebayimg.com/images/g/5O4AAOSw~-dlNVKg/s-l1600.jpg' },
-        { id: 'bike-003', bikeName: 'City Cruiser', pricePerMinute: 0.4, distance: '200 m', imageUrl: 'https://bicicletamontana.com/wp-content/uploads/2020/09/bicicleta-de-paseo.jpg' }
-      ];
+    this.loading = true;
+    this.error = false;
+    this.dashboardService.getDashboardData().subscribe({
+      next: (data: RenterDashboardData) => {
+        this.stats = data.stats;
+        this.upcomingReservation = data.upcomingReservation;
+        this.recentRentals = data.recentRentals;
+        this.recommendations = data.recommendations;
+        this.loading = false;
+      },
+      error: () => {
+        this.error = true;
+        this.loading = false;
+      }
     });
   }
 
@@ -105,8 +104,7 @@ export class RenterHomePage implements OnInit {
 
     dialogRef.afterClosed().subscribe(confirmed => {
       if (confirmed) {
-        this.mockUpcomingReservations = this.mockUpcomingReservations.filter(r => r.id !== reservation.id);
-        this.upcomingReservation = null;
+        this.loadDashboardData();
         this.snackBar.open('Reserva cancelada exitosamente', 'Cerrar', { duration: 3000 });
       }
     });
@@ -126,15 +124,6 @@ export class RenterHomePage implements OnInit {
 
     dialogRef.afterClosed().subscribe(confirmed => {
       if (confirmed) {
-        const newReservation: UpcomingReservation = {
-          id: `res-${Date.now()}`,
-          bikeName: rec.bikeName,
-          date: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
-          address: 'Ubicación de la bicicleta',
-          bikeImage: rec.imageUrl,
-          ownerName: 'Propietario de Bici'
-        };
-        this.mockUpcomingReservations.push(newReservation);
         this.loadDashboardData();
         this.snackBar.open(`¡Has reservado la ${rec.bikeName} exitosamente!`, 'OK', { duration: 3000 });
       }

--- a/src/app/renter/services/dashboard.service.ts
+++ b/src/app/renter/services/dashboard.service.ts
@@ -1,0 +1,20 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+
+export interface RenterDashboardData {
+  stats: any;
+  upcomingReservation: any;
+  recentRentals: any[];
+  recommendations: any[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class DashboardService {
+  private http = inject(HttpClient);
+
+  getDashboardData(): Observable<RenterDashboardData> {
+    return this.http.get<RenterDashboardData>(`${environment.serverBaseUrl}/renter/dashboard`);
+  }
+}

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -10,6 +10,8 @@
   "add_to_favorites": "Add to favorites",
   "not_found": "No stations found for this location.",
   "bike_plural": "bikes",
+  "Common.Loading": "Loading...",
+  "Common.Error": "Error loading data.",
   "Sidebar.Home": "Home",
   "Sidebar.Map": "My map",
   "Sidebar.Profile": "Profile",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -10,6 +10,8 @@
   "add_to_favorites": "Agregar a favoritos",
   "not_found": "No se encontraron estaciones para esta dirección.",
   "bike_plural": "bicicletas",
+  "Common.Loading": "Cargando...",
+  "Common.Error": "Error al cargar datos.",
   "Sidebar.Home": "Inicio",
   "Sidebar.Map": "Mi mapa",
   "Sidebar.Profile": "Perfil",


### PR DESCRIPTION
## Summary
- fetch owner dashboard data and lists using services
- load owner bike list via service
- retrieve reservations from service
- use service for renter dashboard
- load support tickets from service
- show simple loading/error messages
- include new translations for loading/error

## Testing
- `npm test --silent` *(fails: Schema validation failed)*

------
https://chatgpt.com/codex/tasks/task_e_685432f38018832ea7fa24cfa2ad4b22