### PR TITLE
Fix relative imports for auth service

### DIFF
--- a/src/app/public/pages/forgot-password/forgot-password.page.ts
+++ b/src/app/public/pages/forgot-password/forgot-password.page.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { HttpClientModule } from '@angular/common/http';
-import { AuthService } from 'src/app/shared/services/auth.service';
+import { AuthService } from '../../../shared/services/auth.service';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
 @Component({
@@ -28,7 +28,7 @@ export class ForgotPasswordPage {
     }
 
     this.authService.forgotPassword(this.email).subscribe({
-      next: (res) => {
+      next: (res: any) => {
         const id = res?.userId;
         if (id) {
           this.router.navigate(['/reset-password', id]);
@@ -36,7 +36,7 @@ export class ForgotPasswordPage {
           this.router.navigate(['/reset-password']);
         }
       },
-      error: (err) => {
+      error: (err: any) => {
         console.error('Error verifying email:', err);
         alert(this.translate.instant('ForgotPassword.Error'));
       }

--- a/src/app/public/pages/login/login.page.ts
+++ b/src/app/public/pages/login/login.page.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterLink, Router } from '@angular/router';
 import { HttpClientModule } from '@angular/common/http';
-import { AuthService } from 'src/app/shared/services/auth.service';
+import { AuthService } from '../../../shared/services/auth.service';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 
 @Component({
@@ -33,7 +33,7 @@ export class LoginPage {
       return;
     }
     this.authService.login({ email: this.email, password: this.password }).subscribe({
-      next: (res) => {
+      next: (res: any) => {
         const role = localStorage.getItem('userRole');
         if (role === 'owner') {
           this.router.navigate(['/owner/home']);
@@ -43,7 +43,7 @@ export class LoginPage {
           this.router.navigate(['/']);
         }
       },
-      error: err => {
+      error: (err: any) => {
         console.error(err);
         alert(this.translate.instant('Login.Error'));
       }

--- a/src/app/public/pages/register/register.page.ts
+++ b/src/app/public/pages/register/register.page.ts
@@ -3,7 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
-import { AuthService } from 'src/app/shared/services/auth.service';
+import { AuthService } from '../../../shared/services/auth.service';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 
 @Component({
@@ -38,7 +38,7 @@ export class RegisterPage {
         this.resetForm();
         this.router.navigate(['/login']);
       },
-      error: (error) => {
+      error: (error: any) => {
         console.error('Error registering user:', error);
         alert(this.translate.instant('Register.ErrorRegistering'));
       }

--- a/src/app/public/pages/reset-password/reset-password.page.ts
+++ b/src/app/public/pages/reset-password/reset-password.page.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { HttpClientModule } from '@angular/common/http';
-import { AuthService } from 'src/app/shared/services/auth.service';
+import { AuthService } from '../../../shared/services/auth.service';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
 @Component({
@@ -49,7 +49,7 @@ export class ResetPasswordPage implements OnInit {
         alert(this.translate.instant('ResetPassword.Success'));
         this.router.navigate(['/login']);
       },
-      error: (err) => {
+      error: (err: any) => {
         console.error('Error updating password:', err);
         alert(this.translate.instant('ResetPassword.Error'));
       }


### PR DESCRIPTION
## Summary
- use relative path for `AuthService` imports in public pages
- specify parameter types in `subscribe` callbacks

## Testing
- `npm test --silent` *(fails: Schema validation failed)*
- `npm run build --silent` *(fails to inline fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68543bf52d84832ea99bbfefeba23f66